### PR TITLE
Hotfix for crashing error when album only has one track

### DIFF
--- a/src/packages/Album.ts
+++ b/src/packages/Album.ts
@@ -11,17 +11,21 @@ import {
 const parseAlbumInfoTracks = (
   tracks: LastfmOriginalAlbumInfoTrackResponse[]
 ): LastfmAlbumInfoTrack[] => {
-  return tracks.map((track) => ({
-    name: track.name,
-    duration: track.duration,
-    artist: {
-      name: track.artist.name,
-      mbid: track.artist.mbid ?? undefined,
-      url: track.artist.url
-    },
-    url: track.url,
-    rank: track['@attr']?.rank ?? undefined
-  }))
+  if (Array.isArray(tracks)) {
+    return tracks.map((track) => ({
+      name: track.name,
+      duration: track.duration,
+      artist: {
+        name: track.artist.name,
+        mbid: track.artist.mbid ?? undefined,
+        url: track.artist.url
+      },
+      url: track.url,
+      rank: track['@attr']?.rank ?? undefined
+    }))
+  } else {
+    return tracks
+  }
 }
 export class Album {
   constructor(private client: LastClient) {}


### PR DESCRIPTION
Somehow, a single track is being passed when it should be an array, and its breaking `map`